### PR TITLE
Handle `componentWillReceiveProps` for <Switch> support.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,19 @@ export default class LazyRoute extends Component {
 		}
 	}
 	componentDidMount() {
-		this.props.component.then((module) => {
-			this.component = module.default
-			this.setState({loaded: true})
-		})
+		this.loadComponent(this.props.component);
+	}
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.component !== this.props.component) {
+			this.setState({ loaded: false });
+			this.loadComponent(nextProps.component);
+		}
+	}
+	loadComponent(componentPromise) {
+		componentPromise.then((module) => {
+			this.component = module.default;
+			this.setState({ loaded: true });
+		});
 	}
 	render() {
 		const { loaded } = this.state


### PR DESCRIPTION
Reload the component on `component` prop change, which enables <Switch> component support.
Issue #4 .